### PR TITLE
Fix indentation missing from code block

### DIFF
--- a/multi_state_button_instructions.rst
+++ b/multi_state_button_instructions.rst
@@ -186,7 +186,7 @@ overriden.
 
 .. code-block:: html
 
-<label for="ex9_1">Do you like:</label><br>
+  <label for="ex9_1">Do you like:</label><br>
   <p id="ex9_1">
     <select>
       <option value="">Ice cream?</option>


### PR DESCRIPTION
Add missing indentation, the lack of which had broken the code block.